### PR TITLE
Session tracker stack screen and machines

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,12 +1,18 @@
 import { useInterpret } from "@xstate/react";
 import React, { useContext, useMemo } from "react";
 import {
-  AppMachineInterpreter,
+  ProgramBuilderMachineInterpreter,
   createProgramBuilderMachine,
 } from "../machines/ProgramBuilderMachine";
+import {
+  createSessionTrackerMachine,
+  SessionTrackerMachineInterpreter,
+} from "../machines/SessionTrackerMachine";
+import { IS_TEST } from "../types";
 
 interface AppContextValue {
-  programBuilderService: AppMachineInterpreter;
+  programBuilderService: ProgramBuilderMachineInterpreter;
+  sessionTrackerService: SessionTrackerMachineInterpreter;
 }
 
 type AppContextProviderProps = {};
@@ -20,15 +26,26 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
     () => createProgramBuilderMachine(),
     []
   );
+
+  const sessionTrackerMachine = useMemo(
+    () => createSessionTrackerMachine(),
+    []
+  );
+
   const programBuilderService = useInterpret(programBuilderMachine, {
-    devTools: true,
+    devTools: IS_TEST,
+  });
+
+  const sessionTrackerService = useInterpret(sessionTrackerMachine, {
+    devTools: IS_TEST,
   });
   ///
 
   return (
     <AppContext.Provider
       value={{
-        programBuilderService: programBuilderService,
+        programBuilderService,
+        sessionTrackerService,
       }}
     >
       {children}

--- a/machines/ProgramBuilderMachine.ts
+++ b/machines/ProgramBuilderMachine.ts
@@ -34,7 +34,7 @@ export type ProgramBuilderMachineContext = Omit<
   trainingSessionActorRefCollection: TrainingSessionActorRef[];
 };
 
-export type AppMachineInterpreter = InterpreterFrom<
+export type ProgramBuilderMachineInterpreter = InterpreterFrom<
   ReturnType<typeof createProgramBuilderMachine>
 >;
 

--- a/machines/SessionTrackerFormMachine.ts
+++ b/machines/SessionTrackerFormMachine.ts
@@ -1,0 +1,27 @@
+import "react-native-get-random-values";
+import { v4 as uuidv4 } from "uuid";
+import { createMachine, EventFrom } from "xstate";
+
+export type SessionTrackerFormMachineEvents = EventFrom<
+  ReturnType<typeof createSessionTrackerFormMachine>
+>;
+
+export type SessionTrackerFormMachineContext = {};
+
+export const createSessionTrackerFormMachine = () =>
+  /** @xstate-layout N4IgpgJg5mDOIC5QAUBOB7KqCGBbAQgK4CWANhGKgLLYDGAFsQHZgB0AkhKWAMQCCECAAIAKjmbMoQgMpxYxdE0SgADunkAXBUqQgAHogAsh1gDYArAA4AnAHYAjJYBMAZgAMpp7YA0IAJ6I9k7mrPa2hm5elpa2LjYuAL5JvkzoFPC6aJg4BCTklDQMzGyc3Mogapra5QYI1k6sroZOhqaWxkERTr4BCBGsbubW9m5u4aamYfbmySBZWHhEZBTUdIwsrCwA7kKwGtgaYEL25ZXEWoo1gW4m1obmLU71praTLj2ILi4NLhG2TjFHJZftYZglfPMckt8qsiixTupztVdLUnG4zFY7I5XB4vB8EABab6sYZOFqg1rmQykpJJIA */
+  createMachine(
+    {
+      schema: {
+        context: {} as SessionTrackerFormMachineContext,
+        events: {} as {
+          type: "ENTER_TRAINING_SESSION_CREATION_FORM";
+        },
+      },
+      tsTypes: {} as import("./SessionTrackerFormMachine.typegen").Typegen0,
+      context: {},
+      states: {},
+      id: "SessionTrackerMachine",
+    },
+    {}
+  );

--- a/machines/SessionTrackerFormMachine.typegen.ts
+++ b/machines/SessionTrackerFormMachine.typegen.ts
@@ -1,0 +1,21 @@
+// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: never;
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {};
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: undefined;
+  tags: never;
+}

--- a/machines/SessionTrackerMachine.ts
+++ b/machines/SessionTrackerMachine.ts
@@ -1,0 +1,31 @@
+import "react-native-get-random-values";
+import { v4 as uuidv4 } from "uuid";
+import { createMachine, EventFrom, InterpreterFrom } from "xstate";
+
+export type SessionTrackerMachineEvents = EventFrom<
+  ReturnType<typeof createSessionTrackerMachine>
+>;
+
+export type SessionTrackerMachineContext = {};
+
+export type SessionTrackerMachineInterpreter = InterpreterFrom<
+  ReturnType<typeof createSessionTrackerMachine>
+>;
+
+export const createSessionTrackerMachine = () =>
+  /** @xstate-layout N4IgpgJg5mDOIC5QAUBOB7KqCGBbAQgK4CWANhGKgLLYDGAFsQHZgB0AkhKWAMQCCECAAIAKjmbMoQgMpxYxdE0SgADunkAXBUqQgAHogAsh1gDYArAA4AnAHYAjJYBMAZgAMpp7YA0IAJ6I9k7mrPa2hm5elpa2LjYuAL5JvkzoFPC6aJg4BCTklDQMzGyc3Mogapra5QYI1k6sroZOhqaWxkERTr4BCBGsbubW9m5u4aamYfbmySBZWHhEZBTUdIwsrCwA7kKwGtgaYEL25ZXEWoo1gW4m1obmLU71praTLj2ILi4NLhG2TjFHJZftYZglfPMckt8qsiixTupztVdLUnG4zFY7I5XB4vB8EABab6sYZOFqg1rmQykpJJIA */
+  createMachine(
+    {
+      schema: {
+        context: {} as SessionTrackerMachineContext,
+        events: {} as {
+          type: "ENTER_TRAINING_SESSION_CREATION_FORM";
+        },
+      },
+      tsTypes: {} as import("./SessionTrackerMachine.typegen").Typegen0,
+      context: {},
+      states: {},
+      id: "SessionTrackerMachine",
+    },
+    {}
+  );

--- a/machines/SessionTrackerMachine.typegen.ts
+++ b/machines/SessionTrackerMachine.typegen.ts
@@ -1,0 +1,21 @@
+// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: never;
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {};
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: undefined;
+  tags: never;
+}

--- a/navigation/RootStack.tsx
+++ b/navigation/RootStack.tsx
@@ -288,7 +288,7 @@ const ExerciseCreationFormStackNavigator: React.FC = () => {
 
 export type SessionTrackerParamList = {
   Index: undefined;
-  SessionTrackerCreationForm: undefined;
+  SessionTrackerCreationForm: NavigatorScreenParams<SessionTrackerCreationFormParamList>;
 };
 
 const SessionTracker = createNativeStackNavigator<SessionTrackerParamList>();
@@ -345,7 +345,6 @@ export type SessionTrackFormLoadScreenProps = NativeStackScreenProps<
 const SessionTrackerFormStackNavigator: React.FC = () => {
   return (
     <SessionTrackerCreationForm.Navigator
-      initialRouteName="Load"
       screenOptions={{
         headerShown: true,
       }}

--- a/navigation/RootStack.tsx
+++ b/navigation/RootStack.tsx
@@ -15,6 +15,8 @@ import ExerciseCreationFormSetAndRep from "../screens/ExerciseSetAndRep/Exercise
 import ExerciseSetAndRepEditor from "../screens/ExerciseSetAndRep/ExerciseSetAndRepEditor";
 import { HomeScreen } from "../screens/Home";
 import { ProgramBuilderScreen } from "../screens/ProgramBuilder";
+import { SessionTrackerFormLoad } from "../screens/SessionTracker/SessionTrackerFormLoad/SessionTrackerFormLoad";
+import { SessionTrackerIndex } from "../screens/SessionTracker/SessionTrackerIndex";
 import TrainingSessionCreationFormName from "../screens/TrainingSessionName/TrainingSessionCreationFormName";
 import TrainingSessionEditorFormName from "../screens/TrainingSessionName/TrainingSessionEditorFormName";
 
@@ -26,6 +28,7 @@ const BottomTabNavigator =
 export type BottomTabNavigatorParamList = {
   Home: NavigatorScreenParams<HomeStackParamList>;
   ProgramBuilder: NavigatorScreenParams<ProgramBuilderStackParamList>;
+  SessionTracker: NavigatorScreenParams<SessionTrackerCreationFormParamList>;
 };
 
 export type RootHomeScreenProps = NativeStackScreenProps<
@@ -50,6 +53,14 @@ export const BottomTab: React.FC = () => {
         options={{
           tabBarLabel: "Program Builder",
           tabBarTestID: "program-builder-bottom-tab",
+        }}
+      />
+      <BottomTabNavigator.Screen
+        name="SessionTracker"
+        component={SessionTrackerStackNavigator}
+        options={{
+          tabBarLabel: "Session tracker",
+          tabBarTestID: "session-tracker-bottom-tab",
         }}
       />
     </BottomTabNavigator.Navigator>
@@ -268,6 +279,85 @@ const ExerciseCreationFormStackNavigator: React.FC = () => {
         component={ExerciseCreationFormRest}
       />
     </ExerciseCreationForm.Navigator>
+  );
+};
+
+///
+
+// Session tracker stack
+
+export type SessionTrackerParamList = {
+  Index: undefined;
+  SessionTrackerCreationForm: undefined;
+};
+
+const SessionTracker = createNativeStackNavigator<SessionTrackerParamList>();
+
+export type SessionTrackIndexScreenProps = NativeStackScreenProps<
+  SessionTrackerParamList,
+  "Index"
+>;
+
+const SessionTrackerStackNavigator: React.FC = () => {
+  return (
+    <SessionTracker.Navigator
+      initialRouteName="Index"
+      screenOptions={{
+        headerShown: true,
+      }}
+    >
+      <SessionTracker.Screen
+        name="Index"
+        options={{
+          headerTitle: "Session trackers home",
+          headerShown: false,
+        }}
+        component={SessionTrackerIndex}
+      />
+
+      <SessionTracker.Screen
+        name="SessionTrackerCreationForm"
+        options={{
+          headerShown: false,
+        }}
+        component={SessionTrackerFormStackNavigator}
+      />
+    </SessionTracker.Navigator>
+  );
+};
+
+//
+
+// Session tracker form stack
+
+export type SessionTrackerCreationFormParamList = {
+  Load: undefined;
+};
+
+const SessionTrackerCreationForm =
+  createNativeStackNavigator<SessionTrackerCreationFormParamList>();
+
+export type SessionTrackFormLoadScreenProps = NativeStackScreenProps<
+  SessionTrackerCreationFormParamList,
+  "Load"
+>;
+
+const SessionTrackerFormStackNavigator: React.FC = () => {
+  return (
+    <SessionTrackerCreationForm.Navigator
+      initialRouteName="Load"
+      screenOptions={{
+        headerShown: true,
+      }}
+    >
+      <SessionTrackerCreationForm.Screen
+        name="Load"
+        options={{
+          headerTitle: "Session tracker load",
+        }}
+        component={SessionTrackerFormLoad}
+      />
+    </SessionTrackerCreationForm.Navigator>
   );
 };
 

--- a/screens/SessionTracker/SessionTrackerFormLoad/SessionTrackerFormLoad.tsx
+++ b/screens/SessionTracker/SessionTrackerFormLoad/SessionTrackerFormLoad.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { Text } from "react-native";
+import { useTailwind } from "tailwind-rn";
+import AppScreen from "../../../components/AppScreen";
+import { SessionTrackFormLoadScreenProps } from "../../../navigation/RootStack";
+
+export const SessionTrackerFormLoad: React.FC<
+  SessionTrackFormLoadScreenProps
+> = ({ navigation }) => {
+  const tailwind = useTailwind();
+
+  return (
+    <AppScreen testID="session-tracker-form-load-container">
+      <Text style={tailwind("text-blue-600")}>Session tracker Load</Text>
+    </AppScreen>
+  );
+};

--- a/screens/SessionTracker/SessionTrackerIndex.tsx
+++ b/screens/SessionTracker/SessionTrackerIndex.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { Button, Text } from "react-native";
+import { useTailwind } from "tailwind-rn";
+import AppScreen from "../../components/AppScreen";
+import { SessionTrackIndexScreenProps } from "../../navigation/RootStack";
+
+export const SessionTrackerIndex: React.FC<SessionTrackIndexScreenProps> = ({
+  navigation,
+}) => {
+  const tailwind = useTailwind();
+
+  return (
+    <AppScreen testID="session-tracker-index-container">
+      <Text style={tailwind("text-blue-600")}>
+        Session Tracker screen index
+      </Text>
+      <Button
+        onPress={() => {
+          navigation.navigate("SessionTrackerCreationForm");
+        }}
+        title="Start next training session tracker"
+      ></Button>
+    </AppScreen>
+  );
+};

--- a/screens/SessionTracker/SessionTrackerIndex.tsx
+++ b/screens/SessionTracker/SessionTrackerIndex.tsx
@@ -16,7 +16,9 @@ export const SessionTrackerIndex: React.FC<SessionTrackIndexScreenProps> = ({
       </Text>
       <Button
         onPress={() => {
-          navigation.navigate("SessionTrackerCreationForm");
+          navigation.navigate("SessionTrackerCreationForm", {
+            screen: "Load",
+          });
         }}
         title="Start next training session tracker"
       ></Button>

--- a/tailwind.css
+++ b/tailwind.css
@@ -23,16 +23,12 @@
   margin-bottom: 0.25rem
 }
 
-.w-8 {
-  width: 2rem
+.w-full {
+  width: 100%
 }
 
 .w-11\/12 {
   width: 91.666667%
-}
-
-.w-full {
-  width: 100%
 }
 
 .flex-1 {

--- a/tailwind.json
+++ b/tailwind.json
@@ -30,19 +30,14 @@
 			"marginBottom": 4
 		}
 	},
-	"w-8": {
+	"w-full": {
 		"style": {
-			"width": 32
+			"width": "100%"
 		}
 	},
 	"w-11/12": {
 		"style": {
 			"width": "91.666667%"
-		}
-	},
-	"w-full": {
-		"style": {
-			"width": "100%"
 		}
 	},
 	"flex-1": {

--- a/types.ts
+++ b/types.ts
@@ -55,4 +55,4 @@ export type RetrieveUserBodyBuildingProgramResponseBody = z.infer<
   typeof RetrieveUserBodyBuildingProgramResponseBody
 >;
 
-export const IS_TEST = process.env.NODE_ENV;
+export const IS_TEST = process.env.NODE_ENV == "test";


### PR DESCRIPTION
In this PR we've created `SessionTrackerForStackNavigator` and `SessionTrackerStackNavigator`.
Also created empty machines for both screens.
Modified the appContext value to integrate a `SessionTrackerMachineService`